### PR TITLE
Search by adsorbates

### DIFF
--- a/src/main/java/fiuba/tpp/reactorapp/controller/ProcessController.java
+++ b/src/main/java/fiuba/tpp/reactorapp/controller/ProcessController.java
@@ -1,12 +1,15 @@
 package fiuba.tpp.reactorapp.controller;
 
 import fiuba.tpp.reactorapp.entities.Process;
+import fiuba.tpp.reactorapp.model.dto.SearchByAdsorbateDTO;
 import fiuba.tpp.reactorapp.model.exception.ComponentNotFoundException;
 import fiuba.tpp.reactorapp.model.exception.InvalidProcessException;
 import fiuba.tpp.reactorapp.model.exception.InvalidRequestException;
 import fiuba.tpp.reactorapp.model.filter.ProcessFilter;
 import fiuba.tpp.reactorapp.model.request.ProcessRequest;
+import fiuba.tpp.reactorapp.model.request.SearchByAdsorbateRequest;
 import fiuba.tpp.reactorapp.model.response.ProcessResponse;
+import fiuba.tpp.reactorapp.model.response.SearchByAdsorbateResponse;
 import fiuba.tpp.reactorapp.service.ProcessService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -83,6 +86,15 @@ public class ProcessController {
             processes.add(new ProcessResponse(process));
         }
         return processes;
+    }
+
+    @PostMapping(value = "/adsorbato")
+    public List<SearchByAdsorbateResponse> searchBestAdsorbentByAdsorbates(@RequestBody SearchByAdsorbateRequest request){
+        List<SearchByAdsorbateResponse> searchResults = new ArrayList<>();
+        for (SearchByAdsorbateDTO result: processService.searchByAdsorbate(request)) {
+            searchResults.add(new SearchByAdsorbateResponse(result,request.getAdsorbatesIds().size()));
+        }
+        return searchResults;
     }
 
     @GetMapping(value = "/{id}")

--- a/src/main/java/fiuba/tpp/reactorapp/model/dto/SearchByAdsorbateDTO.java
+++ b/src/main/java/fiuba/tpp/reactorapp/model/dto/SearchByAdsorbateDTO.java
@@ -17,9 +17,9 @@ public class SearchByAdsorbateDTO {
     public SearchByAdsorbateDTO(Process process) {
         this.processes = new ArrayList<>();
         this.removeAdsorbates = new ArrayList<>();
-        processes.add(process);
+        this.processes.add(process);
         this.removeAdsorbates.add(process.getAdsorbate());
-        maxQmax = process.getQmax();
+        this.maxQmax = process.getQmax();
     }
 
     public boolean hasAllAdsorbates(Integer numberOfAdsorbates){

--- a/src/main/java/fiuba/tpp/reactorapp/model/dto/SearchByAdsorbateDTO.java
+++ b/src/main/java/fiuba/tpp/reactorapp/model/dto/SearchByAdsorbateDTO.java
@@ -1,0 +1,52 @@
+package fiuba.tpp.reactorapp.model.dto;
+
+import fiuba.tpp.reactorapp.entities.Adsorbate;
+import fiuba.tpp.reactorapp.entities.Process;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchByAdsorbateDTO {
+
+    private List<Process> processes;
+
+    private List<Adsorbate> removeAdsorbates;
+
+    private float maxQmax;
+
+    public SearchByAdsorbateDTO(Process process) {
+        this.processes = new ArrayList<>();
+        this.removeAdsorbates = new ArrayList<>();
+        processes.add(process);
+        this.removeAdsorbates.add(process.getAdsorbate());
+        maxQmax = process.getQmax();
+    }
+
+    public boolean hasAllAdsorbates(Integer numberOfAdsorbates){
+        return removeAdsorbates.size() == numberOfAdsorbates;
+    }
+
+    public List<Process> getProcesses() {
+        return processes;
+    }
+
+    public void setProcesses(List<Process> processes) {
+        this.processes = processes;
+    }
+
+    public float getMaxQmax() {
+        return maxQmax;
+    }
+
+    public void setMaxQmax(float maxQmax) {
+        this.maxQmax = maxQmax;
+    }
+
+    public List<Adsorbate> getRemoveAdsorbates() {
+        return removeAdsorbates;
+    }
+
+    public void setRemoveAdsorbates(List<Adsorbate> removeAdsorbates) {
+        this.removeAdsorbates = removeAdsorbates;
+    }
+}

--- a/src/main/java/fiuba/tpp/reactorapp/model/request/SearchByAdsorbateRequest.java
+++ b/src/main/java/fiuba/tpp/reactorapp/model/request/SearchByAdsorbateRequest.java
@@ -1,0 +1,26 @@
+package fiuba.tpp.reactorapp.model.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class SearchByAdsorbateRequest {
+
+    @JsonProperty("adsorbatos")
+    private List<Long> adsorbatesIds;
+
+    public SearchByAdsorbateRequest() {
+    }
+
+    public SearchByAdsorbateRequest(List<Long> adsorbatesIds) {
+        this.adsorbatesIds = adsorbatesIds;
+    }
+
+    public List<Long> getAdsorbatesIds() {
+        return adsorbatesIds;
+    }
+
+    public void setAdsorbatesIds(List<Long> adsorbatesIds) {
+        this.adsorbatesIds = adsorbatesIds;
+    }
+}

--- a/src/main/java/fiuba/tpp/reactorapp/model/response/SearchByAdsorbateResponse.java
+++ b/src/main/java/fiuba/tpp/reactorapp/model/response/SearchByAdsorbateResponse.java
@@ -1,0 +1,58 @@
+package fiuba.tpp.reactorapp.model.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import fiuba.tpp.reactorapp.entities.Process;
+import fiuba.tpp.reactorapp.model.dto.SearchByAdsorbateDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SearchByAdsorbateResponse {
+
+    @JsonProperty("procesos")
+    private List<ProcessResponse> processes;
+
+    @JsonProperty("maxQmax")
+    private Float maxQmax;
+
+    @JsonProperty("remueveTodosLosAdsorbatos")
+    private boolean removesAllAdsorbates;
+
+    public SearchByAdsorbateResponse() {
+    }
+
+    public SearchByAdsorbateResponse(SearchByAdsorbateDTO result, Integer numberOfAdsorbates) {
+        this.processes = new ArrayList<>();
+        for (Process process: result.getProcesses()) {
+            processes.add(new ProcessResponse(process));
+        }
+        this.maxQmax = result.getMaxQmax();
+        this.removesAllAdsorbates = result.hasAllAdsorbates(numberOfAdsorbates);
+
+
+    }
+
+    public List<ProcessResponse> getProcesses() {
+        return processes;
+    }
+
+    public void setProcesses(List<ProcessResponse> processes) {
+        this.processes = processes;
+    }
+
+    public Float getMaxQmax() {
+        return maxQmax;
+    }
+
+    public void setMaxQmax(Float maxQmax) {
+        this.maxQmax = maxQmax;
+    }
+
+    public boolean isRemovesAllAdsorbates() {
+        return removesAllAdsorbates;
+    }
+
+    public void setRemovesAllAdsorbates(boolean removesAllAdsorbates) {
+        this.removesAllAdsorbates = removesAllAdsorbates;
+    }
+}

--- a/src/main/java/fiuba/tpp/reactorapp/model/response/SearchByAdsorbateResponse.java
+++ b/src/main/java/fiuba/tpp/reactorapp/model/response/SearchByAdsorbateResponse.java
@@ -9,14 +9,17 @@ import java.util.List;
 
 public class SearchByAdsorbateResponse {
 
-    @JsonProperty("procesos")
-    private List<ProcessResponse> processes;
+    @JsonProperty("adsorbente")
+    private AdsorbentResponse adsorbent;
 
     @JsonProperty("maxQmax")
     private Float maxQmax;
 
     @JsonProperty("remueveTodosLosAdsorbatos")
     private boolean removesAllAdsorbates;
+
+    @JsonProperty("procesos")
+    private List<ProcessResponse> processes;
 
     public SearchByAdsorbateResponse() {
     }
@@ -26,10 +29,9 @@ public class SearchByAdsorbateResponse {
         for (Process process: result.getProcesses()) {
             processes.add(new ProcessResponse(process));
         }
+        this.adsorbent = new AdsorbentResponse(result.getProcesses().get(0).getAdsorbent());
         this.maxQmax = result.getMaxQmax();
         this.removesAllAdsorbates = result.hasAllAdsorbates(numberOfAdsorbates);
-
-
     }
 
     public List<ProcessResponse> getProcesses() {
@@ -54,5 +56,13 @@ public class SearchByAdsorbateResponse {
 
     public void setRemovesAllAdsorbates(boolean removesAllAdsorbates) {
         this.removesAllAdsorbates = removesAllAdsorbates;
+    }
+
+    public AdsorbentResponse getAdsorbent() {
+        return adsorbent;
+    }
+
+    public void setAdsorbent(AdsorbentResponse adsorbent) {
+        this.adsorbent = adsorbent;
     }
 }

--- a/src/main/java/fiuba/tpp/reactorapp/repository/ProcessRepository.java
+++ b/src/main/java/fiuba/tpp/reactorapp/repository/ProcessRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-public interface ProcessRepository extends CrudRepository<Process,Long>, ReactorRepositoryCustom {
+public interface ProcessRepository extends CrudRepository<Process,Long>, ProcessRepositoryCustom {
 
     Optional<Process> findByAdsorbentAndAdsorbateAndQmaxAndEquilibriumTimeAndTemperatureAndInitialPH(Adsorbent adsorbent, Adsorbate adsorbate, Float qMax, Float equilibriumTime, Float temperature, Float pH);
 }

--- a/src/main/java/fiuba/tpp/reactorapp/repository/ProcessRepositoryCustom.java
+++ b/src/main/java/fiuba/tpp/reactorapp/repository/ProcessRepositoryCustom.java
@@ -5,7 +5,9 @@ import fiuba.tpp.reactorapp.model.filter.ProcessFilter;
 
 import java.util.List;
 
-public interface ReactorRepositoryCustom {
+public interface ProcessRepositoryCustom {
 
     List<Process> getAll(ProcessFilter filter);
+
+    List<Process> getByAdsorbates(List<Long> adsorbatesIds);
 }

--- a/src/main/java/fiuba/tpp/reactorapp/repository/ProcessRepositoryCustomImpl.java
+++ b/src/main/java/fiuba/tpp/reactorapp/repository/ProcessRepositoryCustomImpl.java
@@ -12,7 +12,7 @@ import javax.persistence.criteria.Root;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ReactorRepositoryCustomImpl implements  ReactorRepositoryCustom{
+public class ProcessRepositoryCustomImpl implements ProcessRepositoryCustom {
 
     @Autowired
     EntityManager em;
@@ -36,5 +36,24 @@ public class ReactorRepositoryCustomImpl implements  ReactorRepositoryCustom{
         cq.where(predicates.toArray(new Predicate[0]));
 
         return em.createQuery(cq).getResultList();
+    }
+
+    @Override
+    public List<Process> getByAdsorbates(List<Long> adsorbatesIds) {
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Process> cq = cb.createQuery(Process.class);
+
+        Root<Process> processRoot = cq.from(Process.class);
+        List<Predicate> predicates = new ArrayList<>();
+
+        if(adsorbatesIds != null && !adsorbatesIds.isEmpty()){
+            predicates.add(processRoot.get("adsorbate").get("id").in(adsorbatesIds));
+        }
+
+        cq.where(predicates.toArray(new Predicate[0]));
+        cq.orderBy(cb.desc(processRoot.get("qmax")));
+
+        return em.createQuery(cq).getResultList();
+
     }
 }

--- a/src/main/java/fiuba/tpp/reactorapp/service/ProcessService.java
+++ b/src/main/java/fiuba/tpp/reactorapp/service/ProcessService.java
@@ -3,18 +3,19 @@ package fiuba.tpp.reactorapp.service;
 import fiuba.tpp.reactorapp.entities.Adsorbate;
 import fiuba.tpp.reactorapp.entities.Adsorbent;
 import fiuba.tpp.reactorapp.entities.Process;
+import fiuba.tpp.reactorapp.model.dto.SearchByAdsorbateDTO;
 import fiuba.tpp.reactorapp.model.exception.ComponentNotFoundException;
 import fiuba.tpp.reactorapp.model.exception.InvalidProcessException;
 import fiuba.tpp.reactorapp.model.filter.ProcessFilter;
 import fiuba.tpp.reactorapp.model.request.ProcessRequest;
+import fiuba.tpp.reactorapp.model.request.SearchByAdsorbateRequest;
 import fiuba.tpp.reactorapp.repository.AdsorbateRepository;
 import fiuba.tpp.reactorapp.repository.AdsorbentRepository;
 import fiuba.tpp.reactorapp.repository.ProcessRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class ProcessService {
@@ -54,6 +55,29 @@ public class ProcessService {
             return;
         }
         throw new ComponentNotFoundException();
+    }
+
+    public List<SearchByAdsorbateDTO> searchByAdsorbate(SearchByAdsorbateRequest request){
+        List<Process> processes = processRepository.getByAdsorbates(request.getAdsorbatesIds());
+        HashMap<Long, SearchByAdsorbateDTO> result = new HashMap<>();
+        for (Process process: processes) {
+            Long idAdsorbent = process.getAdsorbent().getId();
+            if(result.containsKey(idAdsorbent)){
+                addProcessToResult(result.get(idAdsorbent),process);
+            }else{
+                result.put(idAdsorbent,new SearchByAdsorbateDTO(process));
+            }
+        }
+        List<SearchByAdsorbateDTO> orderResult= new ArrayList<>(result.values());
+        orderResult.sort(Comparator.comparing(SearchByAdsorbateDTO::getMaxQmax).reversed());
+        return orderResult;
+    }
+
+    private void addProcessToResult(SearchByAdsorbateDTO result, Process process){
+        result.getProcesses().add(process);
+        if(!result.getRemoveAdsorbates().contains(process.getAdsorbate())){
+            result.getRemoveAdsorbates().add(process.getAdsorbate());
+        }
     }
 
 

--- a/src/test/java/fiuba/tpp/reactorapp/controller/ProcessControllerTest.java
+++ b/src/test/java/fiuba/tpp/reactorapp/controller/ProcessControllerTest.java
@@ -272,6 +272,7 @@ class ProcessControllerTest {
         Assertions.assertFalse(searchResult.get(0).isRemovesAllAdsorbates());
         Assertions.assertEquals(1, searchResult.get(0).getProcesses().size());
         Assertions.assertEquals(0.65f, searchResult.get(0).getMaxQmax());
+        Assertions.assertEquals(1, searchResult.get(0).getAdsorbent().getId());
 
     }
 
@@ -300,6 +301,7 @@ class ProcessControllerTest {
         Assertions.assertFalse(searchResult.get(0).isRemovesAllAdsorbates());
         Assertions.assertEquals(2, searchResult.get(0).getProcesses().size());
         Assertions.assertEquals(0.65f, searchResult.get(0).getMaxQmax());
+        Assertions.assertEquals("Prueba", searchResult.get(0).getAdsorbent().getName());
 
     }
 


### PR DESCRIPTION
Closes #39 

La idea de este endpoint es la siguiente
Le pasas una lista de IDs de Adsorbatos
y te devuelve una lista de resultadosDeBusqueda
La lista viene ordenada por Qmax
Un resultado de busqueda tiene:
-el QMax maximo asociado a ese Adsorbente
-Todos los procesos que involucran a los adsorbados seleccionados y el adsorbente
- un booleano que indica si el adsorbente remueve a todos los adsorbatos buscados o no

Dejo como ejemplo un resultado dentro de la lista de resultados de busqueda

 {
        "procesos": [
            {
                "id": 20,
                "adsorbato": {
                    "id": 8,
                    "nombreIon": "zinc",
                    "nombreIUPAC": "zinc (II)",
                    "cargaIon": 2,
                    "radioIonico": 0.74,
                    "limiteVertido": 0.0,
                    "numeroCAS": "",
                    "formula": "Zn",
                    "cargaIonFormula": "2+"
                },
                "adsorbente": {
                    "id": 4,
                    "nombre": "Hidroxiapatita",
                    "particulaT": "grano (500 - 840 μm)",
                    "sBet": 1.5,
                    "vBet": 0.0044,
                    "pHCargaCero": 0.0
                },
                "qmax": 0.0,
                "tiempoEquilibrio": 120.0,
                "temperatura": 25.0,
                "phinicial": 0.0,
                "complejacion": false,
                "intercambioIonico": true,
                "reaccionQuimica": false,
                "observacion": "",
                "fuente": "Tesis Gómez 2020"
            }
        ],
        "maxQmax": 0.0,
        "remueveTodosLosAdsorbatos": true