### PR TITLE
Refactor mensaje de respuesta

### DIFF
--- a/src/main/java/fiuba/tpp/reactorapp/controller/AdsorbateController.java
+++ b/src/main/java/fiuba/tpp/reactorapp/controller/AdsorbateController.java
@@ -9,6 +9,7 @@ import fiuba.tpp.reactorapp.model.request.AdsorbateRequest;
 import fiuba.tpp.reactorapp.model.response.AdsorbateNameResponse;
 import fiuba.tpp.reactorapp.model.response.AdsorbateResponse;
 import fiuba.tpp.reactorapp.model.response.ProcessCountResponse;
+import fiuba.tpp.reactorapp.model.response.ResponseMessage;
 import fiuba.tpp.reactorapp.service.AdsorbateService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -34,10 +35,13 @@ public class AdsorbateController {
             response = new AdsorbateResponse(adsorbateService.createAdsorbate(request));
         } catch (InvalidRequestException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Los adsorbatos deben tener un nombre y un nombre IUPAC", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.INVALID_ADSORBATE.getMessage(), e);
         } catch (DuplicateIUPACNameException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Ya existe otro adsorbato con ese nombre IUPAC", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.DUPLICATE_ADSORBATE.getMessage(), e);
+        }catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
         return response;
     }
@@ -50,13 +54,16 @@ public class AdsorbateController {
             response = new AdsorbateResponse(adsorbateService.updateAdsorbate(id, request));
         } catch (InvalidRequestException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Es necesario el ID del adsorbato y el nombre IUPAC no puede ser nulo", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.ADSORBATE_INVALID_REQUEST.getMessage(), e);
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El adsorbato no existe", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.ADSORBATE_NOT_FOUND.getMessage(), e);
         } catch (DuplicateIUPACNameException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Ya existe otro adsorbato con ese nombre IUPAC", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.DUPLICATE_ADSORBATE.getMessage(), e);
+        }catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
         return response;
     }
@@ -67,7 +74,10 @@ public class AdsorbateController {
             adsorbateService.deleteAdsorbate(id);
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El adsorbato no existe", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.ADSORBATE_NOT_FOUND.getMessage(), e);
+        } catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
 
     }
@@ -107,7 +117,7 @@ public class AdsorbateController {
             return new AdsorbateResponse((adsorbateService.getById(id)));
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.NOT_FOUND, "El Adsorbato no existe", e);
+                    HttpStatus.NOT_FOUND, ResponseMessage.ADSORBATE_NOT_FOUND.getMessage(), e);
         }
     }
 

--- a/src/main/java/fiuba/tpp/reactorapp/controller/AdsorbentController.java
+++ b/src/main/java/fiuba/tpp/reactorapp/controller/AdsorbentController.java
@@ -9,6 +9,7 @@ import fiuba.tpp.reactorapp.model.request.AdsorbentRequest;
 import fiuba.tpp.reactorapp.model.response.AdsorbentNameResponse;
 import fiuba.tpp.reactorapp.model.response.AdsorbentResponse;
 import fiuba.tpp.reactorapp.model.response.ProcessCountResponse;
+import fiuba.tpp.reactorapp.model.response.ResponseMessage;
 import fiuba.tpp.reactorapp.service.AdsorbentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -34,10 +35,13 @@ public class AdsorbentController {
             response = new AdsorbentResponse(adsorbentService.createAdsorbent(request));
         } catch (InvalidRequestException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Los adsorbentes deben tener un nombre", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.INVALID_ADSORBENT.getMessage(), e);
         } catch (DuplicateAdsorbentException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Ya existe un adsorbente con ese nombre y ese tamaño de particula", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.DUPLICATE_ADSORBENT.getMessage(), e);
+        }catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
         return response;
     }
@@ -47,15 +51,15 @@ public class AdsorbentController {
         AdsorbentResponse response = null;
         try{
             response = new AdsorbentResponse(adsorbentService.updateAdsorbent(id, request));
-        } catch (InvalidRequestException e) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Es necesario el ID del adsorbente", e);
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El adsorbente no existe", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.ADSORBENT_NOT_FOUND.getMessage(), e);
         }catch (DuplicateAdsorbentException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Ya existe un adsorbente con ese nombre y ese tamaño de particula", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.DUPLICATE_ADSORBENT.getMessage(), e);
+        }catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
         return response;
     }
@@ -66,7 +70,10 @@ public class AdsorbentController {
             adsorbentService.deleteAdsorbent(id);
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El adsorbente no existe", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.ADSORBENT_NOT_FOUND.getMessage(), e);
+        } catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
     }
 
@@ -105,7 +112,7 @@ public class AdsorbentController {
             return new AdsorbentResponse(adsorbentService.getById(id));
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.NOT_FOUND, "El Adsorbente no existe", e);
+                    HttpStatus.NOT_FOUND, ResponseMessage.ADSORBENT_NOT_FOUND.getMessage(), e);
         }
     }
 

--- a/src/main/java/fiuba/tpp/reactorapp/controller/AuthController.java
+++ b/src/main/java/fiuba/tpp/reactorapp/controller/AuthController.java
@@ -6,6 +6,7 @@ import fiuba.tpp.reactorapp.model.auth.request.LoginRequest;
 import fiuba.tpp.reactorapp.model.auth.request.RegisterRequest;
 import fiuba.tpp.reactorapp.model.auth.response.LoginResponse;
 import fiuba.tpp.reactorapp.model.auth.response.RegisterResponse;
+import fiuba.tpp.reactorapp.model.response.ResponseMessage;
 import fiuba.tpp.reactorapp.service.auth.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -32,10 +33,13 @@ public class AuthController {
             return authService.register(registerRequest);
         } catch (EmailAlreadyExistException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El email ya existe en el sistema", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.DUPLICATE_EMAIL.getMessage(), e);
         } catch (InvalidRegisterException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El email es invalido o no cumple con un formato correcto", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.INVALID_REGISTER.getMessage(), e);
+        }catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
     }
 

--- a/src/main/java/fiuba/tpp/reactorapp/controller/ProcessController.java
+++ b/src/main/java/fiuba/tpp/reactorapp/controller/ProcessController.java
@@ -9,6 +9,7 @@ import fiuba.tpp.reactorapp.model.filter.ProcessFilter;
 import fiuba.tpp.reactorapp.model.request.ProcessRequest;
 import fiuba.tpp.reactorapp.model.request.SearchByAdsorbateRequest;
 import fiuba.tpp.reactorapp.model.response.ProcessResponse;
+import fiuba.tpp.reactorapp.model.response.ResponseMessage;
 import fiuba.tpp.reactorapp.model.response.SearchByAdsorbateResponse;
 import fiuba.tpp.reactorapp.service.ProcessService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,10 +36,13 @@ public class ProcessController {
             response = new ProcessResponse(processService.createProcess(request));
         } catch (InvalidRequestException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El proceso debe estar conformado de un adsorbato o un adsorbente", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.PROCESS_INVALID_REQUEST.getMessage(), e);
         } catch (InvalidProcessException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Adsorbente o Adsorbato invalidos", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.INVALID_PROCESS_CREATE.getMessage(), e);
+        } catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
         return response;
     }
@@ -50,7 +54,10 @@ public class ProcessController {
             response = new ProcessResponse(processService.updateProcess(id, request));
         } catch (InvalidProcessException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "Adsorbato,Adsorbente o reactor invalido", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.INVALID_PROCESS.getMessage(), e);
+        } catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
         return response;
     }
@@ -61,7 +68,10 @@ public class ProcessController {
             processService.deleteProcess(id);
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST, "El proceso no existe", e);
+                    HttpStatus.BAD_REQUEST, ResponseMessage.PROCESS_NOT_FOUND.getMessage(), e);
+        }catch(Exception e){
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_ERROR.getMessage(), e);
         }
     }
 
@@ -99,7 +109,7 @@ public class ProcessController {
             return new ProcessResponse(processService.getById(id));
         } catch (ComponentNotFoundException e) {
             throw new ResponseStatusException(
-                    HttpStatus.NOT_FOUND, "El proceso no existe", e);
+                    HttpStatus.NOT_FOUND, ResponseMessage.PROCESS_NOT_FOUND.getMessage(), e);
         }
     }
     private void validateProcess(ProcessRequest request) throws InvalidRequestException {

--- a/src/main/java/fiuba/tpp/reactorapp/model/auth/exception/EmailAlreadyExistException.java
+++ b/src/main/java/fiuba/tpp/reactorapp/model/auth/exception/EmailAlreadyExistException.java
@@ -1,4 +1,4 @@
 package fiuba.tpp.reactorapp.model.auth.exception;
 
-public class EmailAlreadyExistException extends Exception{
+public class EmailAlreadyExistException extends RuntimeException{
 }

--- a/src/main/java/fiuba/tpp/reactorapp/model/response/ResponseMessage.java
+++ b/src/main/java/fiuba/tpp/reactorapp/model/response/ResponseMessage.java
@@ -1,0 +1,28 @@
+package fiuba.tpp.reactorapp.model.response;
+
+public enum ResponseMessage {
+    DUPLICATE_ADSORBATE("Ya existe otro adsorbato con ese nombre IUPAC"),
+    INVALID_ADSORBATE("Los adsorbatos deben tener un nombre y un nombre IUPAC"),
+    ADSORBATE_NOT_FOUND("El adsorbato no existe"),
+    ADSORBATE_INVALID_REQUEST("Es necesario el ID del adsorbato y el nombre IUPAC no puede ser nulo"),
+    DUPLICATE_ADSORBENT("Ya existe un adsorbente con ese nombre y ese tamaño de particula"),
+    INVALID_ADSORBENT("Los adsorbentes deben tener un nombre"),
+    ADSORBENT_NOT_FOUND("El Adsorbente no existe"),
+    PROCESS_NOT_FOUND("El proceso no existe"),
+    INVALID_PROCESS("Adsorbato,Adsorbente o reactor invalido"),
+    PROCESS_INVALID_REQUEST("El proceso debe estar conformado de un adsorbato o un adsorbente"),
+    INVALID_PROCESS_CREATE("Adsorbente o Adsorbato invalidos"),
+    DUPLICATE_EMAIL("El email ya existe en el sistema"),
+    INVALID_REGISTER("El email es invalido o no cumple con un formato correcto"),
+    INTERNAL_ERROR("Ocurrio un error inesperado");
+
+    private final String message;
+
+    ResponseMessage(String message){
+        this.message= message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/fiuba/tpp/reactorapp/service/AdsorbateService.java
+++ b/src/main/java/fiuba/tpp/reactorapp/service/AdsorbateService.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,7 +59,9 @@ public class AdsorbateService {
     }
 
     public List<Adsorbate> getAll(){
-        return (List<Adsorbate>) adsorbateRepository.findAll();
+        List<Adsorbate> adsorbates = (List<Adsorbate>) adsorbateRepository.findAll();
+        adsorbates.sort(Comparator.comparing(Adsorbate::getIonName));
+        return adsorbates;
     }
 
     public List<Adsorbate> search(AdsorbateFilter filter){

--- a/src/main/java/fiuba/tpp/reactorapp/service/AdsorbentService.java
+++ b/src/main/java/fiuba/tpp/reactorapp/service/AdsorbentService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import fiuba.tpp.reactorapp.model.filter.AdsorbentFilter;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -54,7 +55,9 @@ public class AdsorbentService {
     }
 
     public List<Adsorbent> getAll(){
-        return (List<Adsorbent>) adsorbentRepository.findAll();
+        List<Adsorbent> adsorbents = (List<Adsorbent>) adsorbentRepository.findAll();
+        adsorbents.sort(Comparator.comparing(Adsorbent::getName));
+        return adsorbents;
     }
 
     public List<Adsorbent> search(AdsorbentFilter filter){

--- a/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbateControllerTest.java
+++ b/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbateControllerTest.java
@@ -1,14 +1,16 @@
 package fiuba.tpp.reactorapp.controller;
 
-import fiuba.tpp.reactorapp.model.exception.InvalidRequestException;
 import fiuba.tpp.reactorapp.model.request.AdsorbateRequest;
 import fiuba.tpp.reactorapp.model.response.AdsorbateNameResponse;
 import fiuba.tpp.reactorapp.model.response.AdsorbateResponse;
-import fiuba.tpp.reactorapp.model.response.ProcessResponse;
 import fiuba.tpp.reactorapp.model.response.ResponseMessage;
+import fiuba.tpp.reactorapp.service.AdsorbateService;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -22,6 +24,12 @@ class AdsorbateControllerTest {
 
     @Autowired
     private AdsorbateController adsorbateController;
+
+    @Mock
+    private AdsorbateService adsorbateService;
+
+    @InjectMocks
+    private AdsorbateController adsorbateMockController = new AdsorbateController();
 
     @Test
     void testCreateAdsorbate(){
@@ -235,6 +243,42 @@ class AdsorbateControllerTest {
         Assert.assertEquals(ResponseMessage.DUPLICATE_ADSORBATE.getMessage(),e.getReason());
 
     }
+
+    @Test
+    void testUpdateAdsorbateInternalError() {
+        AdsorbateRequest requestUpdate = new AdsorbateRequest("Prueba2","IUPAC2",1,10f,100f);
+        Mockito.when(adsorbateService.updateAdsorbate(1L,requestUpdate)).thenThrow(RuntimeException.class);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            adsorbateMockController.updateAdsorbate(1L, requestUpdate);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+
+    @Test
+    void testCreateAdsorbateInternalError() {
+        AdsorbateRequest request = new AdsorbateRequest("Prueba2","IUPAC2",1,10f,100f);
+        Mockito.when(adsorbateService.createAdsorbate(request)).thenThrow(RuntimeException.class);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            adsorbateMockController.createAdsorbate(request);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+
+    @Test
+    void testDeleteAdsorbateInternalError() {
+        Mockito.doThrow(RuntimeException.class).when(adsorbateService).deleteAdsorbate(1L);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            adsorbateMockController.deleteAdsorbate(1L);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+    
 
 
 }

--- a/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbateControllerTest.java
+++ b/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbateControllerTest.java
@@ -5,6 +5,7 @@ import fiuba.tpp.reactorapp.model.request.AdsorbateRequest;
 import fiuba.tpp.reactorapp.model.response.AdsorbateNameResponse;
 import fiuba.tpp.reactorapp.model.response.AdsorbateResponse;
 import fiuba.tpp.reactorapp.model.response.ProcessResponse;
+import fiuba.tpp.reactorapp.model.response.ResponseMessage;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -38,9 +39,10 @@ class AdsorbateControllerTest {
     void testCreateAdsorbateWithoutName(){
         AdsorbateRequest request = new AdsorbateRequest(null,"PruebaIUPAC",1,1f,10f);
 
-        Assertions.assertThrows(ResponseStatusException.class, () -> {
-            AdsorbateResponse adsorbato = adsorbateController.createAdsorbate(request);
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            adsorbateController.createAdsorbate(request);
         });
+        Assert.assertEquals(ResponseMessage.INVALID_ADSORBATE.getMessage(),e.getReason());
     }
 
     @Test
@@ -75,9 +77,10 @@ class AdsorbateControllerTest {
         requestUpdate.setId(2L);
         adsorbateController.createAdsorbate(request);
 
-        Assertions.assertThrows(ResponseStatusException.class, () -> {
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
             adsorbateController.updateAdsorbate(2L, requestUpdate);
         });
+        Assert.assertEquals(ResponseMessage.ADSORBATE_NOT_FOUND.getMessage(),e.getReason());
     }
 
     @Test
@@ -202,18 +205,20 @@ class AdsorbateControllerTest {
 
     @Test
     void testGetAdsorbateByIdNotFound(){
-        Assertions.assertThrows(ResponseStatusException.class, () -> {
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
            adsorbateController.getAdsorbate(20L);
         });
+        Assert.assertEquals(ResponseMessage.ADSORBATE_NOT_FOUND.getMessage(),e.getReason());
     }
 
     @Test
     void testCreateAdsorbateNameIUPACDuplicate() {
         AdsorbateRequest request = new AdsorbateRequest("CARLOS","IUPAC",1,1f,10f);
         adsorbateController.createAdsorbate(request);
-        Assertions.assertThrows(ResponseStatusException.class, () -> {
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
             adsorbateController.createAdsorbate(request);
         });
+        Assert.assertEquals(ResponseMessage.DUPLICATE_ADSORBATE.getMessage(),e.getReason());
     }
 
     @Test
@@ -224,9 +229,11 @@ class AdsorbateControllerTest {
         adsorbateController.createAdsorbate(request2);
 
         AdsorbateRequest requestUpdate = new AdsorbateRequest("Prueba2","IUPAC2",1,10f,100f);
-        Assertions.assertThrows(ResponseStatusException.class, () -> {
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
             adsorbateController.updateAdsorbate(1L, requestUpdate);
         });
+        Assert.assertEquals(ResponseMessage.DUPLICATE_ADSORBATE.getMessage(),e.getReason());
+
     }
 
 

--- a/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbateControllerTest.java
+++ b/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbateControllerTest.java
@@ -276,9 +276,6 @@ class AdsorbateControllerTest {
             adsorbateMockController.deleteAdsorbate(1L);
         });
         Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
-
     }
-    
-
 
 }

--- a/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbentControllerTest.java
+++ b/src/test/java/fiuba/tpp/reactorapp/controller/AdsorbentControllerTest.java
@@ -3,9 +3,14 @@ package fiuba.tpp.reactorapp.controller;
 import fiuba.tpp.reactorapp.model.request.AdsorbentRequest;
 import fiuba.tpp.reactorapp.model.response.AdsorbentNameResponse;
 import fiuba.tpp.reactorapp.model.response.AdsorbentResponse;
+import fiuba.tpp.reactorapp.model.response.ResponseMessage;
+import fiuba.tpp.reactorapp.service.AdsorbentService;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -19,6 +24,12 @@ class AdsorbentControllerTest {
 
     @Autowired
     private AdsorbentController adsorbentController;
+
+    @Mock
+    private AdsorbentService adsorbentService;
+
+    @InjectMocks
+    private AdsorbentController adsorbentMockController = new AdsorbentController();
 
     @Test
     void testCreateAdsorbent(){
@@ -172,5 +183,40 @@ class AdsorbentControllerTest {
         requestUpdate.setId(1L);
 
         Assertions.assertThrows(ResponseStatusException.class, () -> adsorbentController.createAdsorbent(request));
+    }
+
+    @Test
+    void testUpdateAdsorbentInternalError() {
+        AdsorbentRequest requestUpdate = new AdsorbentRequest("Prueba2", "Prueba2", 10f, 10f,10f);
+        Mockito.when(adsorbentService.updateAdsorbent(1L,requestUpdate)).thenThrow(RuntimeException.class);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            adsorbentMockController.updateAdsorbent(1L, requestUpdate);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+
+    @Test
+    void testCreateAdsorbentInternalError() {
+        AdsorbentRequest request = new AdsorbentRequest("Prueba2", "Prueba2", 10f, 10f,10f);
+        Mockito.when(adsorbentService.createAdsorbent(request)).thenThrow(RuntimeException.class);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            adsorbentMockController.createAdsorbent(request);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+
+    @Test
+    void testDeleteAdsorbentInternalError() {
+        Mockito.doThrow(RuntimeException.class).when(adsorbentService).deleteAdsorbent(1L);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            adsorbentMockController.deleteAdsorbent(1L);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
     }
 }

--- a/src/test/java/fiuba/tpp/reactorapp/controller/AuthControllerTest.java
+++ b/src/test/java/fiuba/tpp/reactorapp/controller/AuthControllerTest.java
@@ -1,11 +1,19 @@
 package fiuba.tpp.reactorapp.controller;
 
+import fiuba.tpp.reactorapp.model.auth.exception.EmailAlreadyExistException;
 import fiuba.tpp.reactorapp.model.auth.request.LoginRequest;
 import fiuba.tpp.reactorapp.model.auth.request.RegisterRequest;
 import fiuba.tpp.reactorapp.model.auth.response.LoginResponse;
 import fiuba.tpp.reactorapp.model.auth.response.RegisterResponse;
+import fiuba.tpp.reactorapp.model.response.ResponseMessage;
+import fiuba.tpp.reactorapp.service.AdsorbentService;
+import fiuba.tpp.reactorapp.service.auth.AuthService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -20,6 +28,13 @@ class AuthControllerTest {
 
     @Autowired
     private AuthController authController;
+
+    @Mock
+    private AuthService authService;
+
+    @InjectMocks
+    private AuthController authMockController = new AuthController();
+
 
     @Test
     void testRegisterUserAndLogin(){
@@ -66,5 +81,15 @@ class AuthControllerTest {
         Assert.assertThrows(ResponseStatusException.class, () ->{
             authController.registerUser(request2);
         });
+    }
+
+    @Test
+    void testRegisterUserInternalErrror() {
+        RegisterRequest request = new RegisterRequest("mati@gmail.com","Prueba123");
+        Mockito.when(authService.register(request)).thenThrow(RuntimeException.class);
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            authMockController.registerUser(request);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
     }
 }

--- a/src/test/java/fiuba/tpp/reactorapp/controller/ProcessControllerTest.java
+++ b/src/test/java/fiuba/tpp/reactorapp/controller/ProcessControllerTest.java
@@ -5,9 +5,13 @@ import fiuba.tpp.reactorapp.model.request.AdsorbentRequest;
 import fiuba.tpp.reactorapp.model.request.ProcessRequest;
 import fiuba.tpp.reactorapp.model.request.SearchByAdsorbateRequest;
 import fiuba.tpp.reactorapp.model.response.*;
+import fiuba.tpp.reactorapp.service.ProcessService;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -28,6 +32,12 @@ class ProcessControllerTest {
 
     @Autowired
     private AdsorbateController adsorbateController;
+
+    @Mock
+    ProcessService processService;
+
+    @InjectMocks
+    ProcessController processMockController = new ProcessController();
 
 
     @Test
@@ -305,7 +315,7 @@ class ProcessControllerTest {
     @Test
     void testGetProcessByIdNotFound(){
         Assertions.assertThrows(ResponseStatusException.class, () -> {
-            ProcessResponse processResponse = processController.getProcess(20L);
+            processController.getProcess(20L);
         });
     }
 
@@ -344,4 +354,42 @@ class ProcessControllerTest {
 
         Assertions.assertEquals(1, count.getProcessCount());
     }
+
+    @Test
+    void testUpdateProcessInternalError() {
+        ProcessRequest requestUpdate = new ProcessRequest(65f,1f,1f,1f,true,true,true);
+        Mockito.when(processService.updateProcess(1L,requestUpdate)).thenThrow(RuntimeException.class);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            processMockController.updateProcess(1L, requestUpdate);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+
+    @Test
+    void testCreateProcessInternalError() {
+        ProcessRequest request = new ProcessRequest(65f,1f,1f,1f,true,true,true);
+        request.setIdAdsorbate(1L);
+        request.setIdAdsorbent(1L);
+        Mockito.when(processService.createProcess(request)).thenThrow(RuntimeException.class);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            processMockController.createProcess(request);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+
+    @Test
+    void testDeleteAdsorbentInternalError() {
+        Mockito.doThrow(RuntimeException.class).when(processService).deleteProcess(1L);
+
+        ResponseStatusException e = Assertions.assertThrows(ResponseStatusException.class, () -> {
+            processMockController.deleteProcess(1L);
+        });
+        Assert.assertEquals(ResponseMessage.INTERNAL_ERROR.getMessage(),e.getReason());
+
+    }
+
 }


### PR DESCRIPTION
Refactor para evitar errores en el front y centralizar los mensajes de respuesta.
Ademasl os get generales son ne orden alfabetico por bug detectado en el front